### PR TITLE
fix :: 학사일정 캘린더 뷰 학년 구분 색 오류 수정

### DIFF
--- a/src/hooks/Schedule/useCalendarSchedule.ts
+++ b/src/hooks/Schedule/useCalendarSchedule.ts
@@ -25,7 +25,7 @@ const useCalendarSchedule = () => {
   }, [schedulesData]);
 
   const calendarScheduleTransform = (schedule: Schedule) => {
-    const scheduleColor = dataTransform.convertGradeToColor("1학년"); //todo : api 수정시 변경 필요
+    const scheduleColor = dataTransform.convertGradeToColor(dataTransform.convertGrade(schedule.targetGrades[0])); //todo : api 수정시 변경 필요
 
     const newHandleSchedule = {
       id: schedule.id,

--- a/src/types/Schedule/schedule.type.ts
+++ b/src/types/Schedule/schedule.type.ts
@@ -29,9 +29,4 @@ export interface ScheduleResponse extends Response {
 
 export type ScheduleType = "ACADEMIC" | "HOLIDAY";
 
-export type ScheduleTargetGrade =
-  | "GRADE_1"
-  | "GRADE_2"
-  | "GRADE_3"
-  | "GRADE_ALL"
-  | "GRADE_ETC";
+export type ScheduleTargetGrade = "GRADE_1" | "GRADE_2" | "GRADE_3" | "GRADE_ALL" | "GRADE_ETC";


### PR DESCRIPTION
## ⛳️ 작업 내용

- 학사일정 캘린더 뷰에서 일정 옆 학년 별 색이 제대로 뜨지않던 부분 수정

수정전
<img width="1710" alt="스크린샷 2024-06-10 오전 10 37 16" src="https://github.com/Team-B1ND/dodamdodam-teacher-web/assets/132974029/4562430f-72ea-4c41-b6dc-ebd8a0ba460b">

수정후
<img width="1710" alt="스크린샷 2024-06-10 오전 10 37 29" src="https://github.com/Team-B1ND/dodamdodam-teacher-web/assets/132974029/3ca060f0-7c3b-4084-9c60-5ee479f6aefa">
