### PR TITLE
refactor :: sortByGradeNum -> Approval #90

### DIFF
--- a/src/utils/Out/outGoingDataFilter.ts
+++ b/src/utils/Out/outGoingDataFilter.ts
@@ -1,5 +1,5 @@
-import { changeRoom } from "utils/Member/changeGrade";
-import { OutResponse } from "types/Out/out.type";
+import { changeRoom } from 'utils/Member/changeGrade';
+import { OutResponse } from 'types/Out/out.type';
 
 export const outGoingDataFilter = (
   OffBasePass: OutResponse | undefined,
@@ -7,21 +7,28 @@ export const outGoingDataFilter = (
   selectGrade: number,
   selectApproval: string | undefined,
   selectMealDemand: number,
-  selectRoom: string,
+  selectRoom: string
 ) => {
   const sortedData = OffBasePass?.data
     .filter((pass) => pass.student.name.includes(studentName))
     .filter((data) => data.student.grade === selectGrade || selectGrade === 0)
-    .filter((data) => data.status === selectApproval || selectApproval === "")
+    .filter((data) => data.status === selectApproval || selectApproval === '')
     .filter((data) => data.student?.room === changeRoom(selectRoom) || changeRoom(selectRoom) === 0)
     .filter(
       (data) =>
         selectMealDemand === 0 ||
         (selectMealDemand === 1 && data.dinnerOrNot) ||
         (selectMealDemand === 2 && !data.dinnerOrNot) ||
-        selectMealDemand === -1,
+        selectMealDemand === -1
     )
     .sort((a, b) => {
+      if (a.status === 'PENDING' && b.status !== 'PENDING') {
+        return -1;
+      }
+      if (a.status !== 'PENDING' && b.status === 'PENDING') {
+        return 1;
+      }
+
       if (a.student.grade === b.student.grade) {
         if (a.student.room === b.student.room) {
           return a.student.number - b.student.number;
@@ -30,6 +37,5 @@ export const outGoingDataFilter = (
       }
       return a.student.grade - b.student.grade;
     });
-
   return sortedData;
 };

--- a/src/utils/Out/outSleepingDataFilter.ts
+++ b/src/utils/Out/outSleepingDataFilter.ts
@@ -1,19 +1,26 @@
-import { OutResponse } from "types/Out/out.type";
-import { changeRoom } from "utils/Member/changeGrade";
+import { OutResponse } from 'types/Out/out.type';
+import { changeRoom } from 'utils/Member/changeGrade';
 
 export const outSleepingDataFilter = (
   OffBaseLeave: OutResponse | undefined,
   studentName: string,
   selectGrade: number,
   selectApproval: string | undefined,
-  selectRoom: string,
+  selectRoom: string
 ) => {
   return OffBaseLeave?.data
     .filter((pass) => pass.student.name.includes(studentName))
     .filter((data) => data.student.grade === selectGrade || selectGrade === 0)
-    .filter((data) => data.status === selectApproval || selectApproval === "")
+    .filter((data) => data.status === selectApproval || selectApproval === '')
     .filter((data) => data.student?.room === changeRoom(selectRoom) || changeRoom(selectRoom) === 0)
     .sort((a, b) => {
+      if (a.status === 'PENDING' && b.status !== 'PENDING') {
+        return -1;
+      }
+      if (a.status !== 'PENDING' && b.status === 'PENDING') {
+        return 1;
+      }
+
       if (a.student.grade === b.student.grade) {
         if (a.student.room === b.student.room) {
           return a.student.number - b.student.number;


### PR DESCRIPTION
## ⛳️ 작업 내용

- 현재 외출, 외박의 기본 정렬 기준이 학반순
- 위의 방식으로 계속 진행 될 경우 수요일이나 금요일같이 외출, 외박자가 많아지면 신청을 수락하기 어려운 문제 발생
- 기본 정렬 기준을 학반순 -> 승인 여부 순으로 변경
- 승인여부에 따른 Select를 이용하면 되지만 사용자들에게 좀 더 빠르게 기능을 이용할 수 있도록 하기 위함

## 📸 스크린샷

### before
**외출**
<img width="1710" alt="스크린샷 2024-11-21 오전 8 38 33" src="https://github.com/user-attachments/assets/6c9cd8b1-05f1-4257-a38d-9da84d524f5b">

**외박**
<img width="1710" alt="스크린샷 2024-11-21 오전 8 38 56" src="https://github.com/user-attachments/assets/11e29e60-6219-4354-8475-13dc9af2ef19">

### after
**외출**
<img width="1710" alt="스크린샷 2024-11-21 오전 8 39 35" src="https://github.com/user-attachments/assets/0ab78d4e-a0ce-4869-ab09-9e31ddab3193">

**외박**
<img width="1710" alt="스크린샷 2024-11-21 오전 8 39 48" src="https://github.com/user-attachments/assets/c0373b2b-0731-4aa7-86b8-131a7ce0edef">
